### PR TITLE
refactor: move serviceKey from DTO hardcoding to service layer with @…

### DIFF
--- a/src/main/java/com/bubble/bubbleforprofessor/university/dto/request/UniversityApiRequest.java
+++ b/src/main/java/com/bubble/bubbleforprofessor/university/dto/request/UniversityApiRequest.java
@@ -7,10 +7,8 @@ import org.springframework.beans.factory.annotation.Value;
 @Getter
 @AllArgsConstructor
 public class UniversityApiRequest {
-   // @Value("${universityApi.serviceKey}")
 
-    @Builder.Default
-    private String serviceKey="W9J4P7PW-W9J4-W9J4-W9J4-W9J4P7PW4Y";
+    private String serviceKey;
 
     @Builder.Default
     private int pageNo = 1;

--- a/src/main/java/com/bubble/bubbleforprofessor/university/service/UniversityServiceImpl.java
+++ b/src/main/java/com/bubble/bubbleforprofessor/university/service/UniversityServiceImpl.java
@@ -11,6 +11,7 @@ import jakarta.annotation.PostConstruct;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -44,6 +45,8 @@ public class UniversityServiceImpl implements UniversityService {
 
     private final UniversityElasticSearchRepository esSearchRepository;
 
+    @Value("${universityApi.serviceKey}")
+    private String serviceKey;
 
     @PostConstruct
     public void init(){
@@ -67,17 +70,17 @@ public class UniversityServiceImpl implements UniversityService {
     public Mono<Void> saveAllUniversities(UniversityApiRequest uniRequest) {
         // Step 1: 초기 값 요청으로 totalCount 가져오기
         UniversityApiRequest initRequest = UniversityApiRequest.builder()
-                .serviceKey(uniRequest.getServiceKey())
+                .serviceKey(serviceKey)
                 .pageNo(uniRequest.getPageNo())
                 .dataType(uniRequest.getDataType())
                 .fcltyCd(uniRequest.getFcltyCd())
                 .numOfRows(1)
                 .build();
-
+        log.info("initRequest 생성 - pageNo: {}, fcltyCd; {}", initRequest.getPageNo(), initRequest.getFcltyCd());
         return webClient.get()
                 .uri(uriBuilder -> uriBuilder
                         .path("/data/getUniversity.do")
-                        .queryParam("serviceKey", initRequest.getServiceKey())
+                        .queryParam("serviceKey", serviceKey)
                         .queryParam("pageNo", initRequest.getPageNo())
                         .queryParam("numOfRows", initRequest.getNumOfRows())
                         .queryParam("dataType", initRequest.getDataType())
@@ -98,7 +101,7 @@ public class UniversityServiceImpl implements UniversityService {
                     int totalCount = initResponse.getBody().getTotalCount();
                     log.info("Total count: {}", totalCount);
                     UniversityApiRequest fullRequest = UniversityApiRequest.builder()
-                            .serviceKey(uniRequest.getServiceKey())
+                            .serviceKey(serviceKey)
                             .pageNo(uniRequest.getPageNo())
                             .dataType(uniRequest.getDataType())
                             .fcltyCd(uniRequest.getFcltyCd())
@@ -109,7 +112,7 @@ public class UniversityServiceImpl implements UniversityService {
                 return webClient.get()
                         .uri(uriBuilder -> uriBuilder
                                 .path("/data/getUniversity.do")
-                                .queryParam("serviceKey",fullRequest.getServiceKey())
+                                .queryParam("serviceKey",serviceKey)
                                 .queryParam("pageNo", fullRequest.getPageNo())
                                 .queryParam("numOfRows", fullRequest.getNumOfRows())
                                 .queryParam("dataType", fullRequest.getDataType())
@@ -135,7 +138,7 @@ public class UniversityServiceImpl implements UniversityService {
                                     .isDeleted(false)
                                     .build())
                             .collect(Collectors.toList());
-
+                    log.info("fullRequest 생성 - pageNo: {}, fcltyCd; {}", initRequest.getPageNo(), initRequest.getFcltyCd());
                     return Mono.fromRunnable(() -> saveToDb(universities))
                             .subscribeOn(Schedulers.boundedElastic())
                             .onErrorResume(e -> {


### PR DESCRIPTION
### 변경 내용
- `UniversityApiRequest` DTO에서 `serviceKey` 하드코딩 제거
- 서비스 레이어(`UniversityServiceImpl`)에서 `@Value`로 주입하여 동적으로 설정
- DTO는 이제 순수 데이터 구조로 유지되고, 설정 주입은 서비스 레이어에서 담당