### PR TITLE
refator: 기존 @AllArgsConstructor 제거 후 생성자 수정 정의 및 테스트코드 리팩터링

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,7 @@
 			<scope>test</scope>
 		</dependency>
 
+
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-junit-jupiter</artifactId>

--- a/src/main/java/com/bubble/bubbleforprofessor/university/dto/request/UniversityApiRequest.java
+++ b/src/main/java/com/bubble/bubbleforprofessor/university/dto/request/UniversityApiRequest.java
@@ -5,7 +5,6 @@ import org.springframework.beans.factory.annotation.Value;
 
 @Builder
 @Getter
-@AllArgsConstructor
 public class UniversityApiRequest {
 
     private String serviceKey;
@@ -19,6 +18,14 @@ public class UniversityApiRequest {
 
     @Builder.Default
     private String fcltyCd = "502040";
+
+    public UniversityApiRequest(String serviceKey, int pageNo, int numOfRows, String dataType, String fcltyCd) {
+        this.serviceKey = serviceKey;
+        this.pageNo = pageNo;
+        this.numOfRows = numOfRows;
+        this.dataType = dataType;
+        this.fcltyCd = fcltyCd;
+    }
 
 
 }

--- a/src/main/java/com/bubble/bubbleforprofessor/university/dto/response/Body.java
+++ b/src/main/java/com/bubble/bubbleforprofessor/university/dto/response/Body.java
@@ -4,9 +4,7 @@ import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlElementWrapper;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.util.List;
 
@@ -14,6 +12,7 @@ import java.util.List;
 @Getter
 @XmlAccessorType(XmlAccessType.FIELD)
 @NoArgsConstructor
+@Builder
 public class Body {
     @XmlElementWrapper(name = "items")
     @XmlElement(name = "item")
@@ -27,4 +26,11 @@ public class Body {
 
     @XmlElement(name = "totalCount")
     private int totalCount;
+
+    public Body(List<UniversityList> items, int numOfRows, int pageNo, int totalCount) {
+        this.items = items;
+        this.numOfRows = numOfRows;
+        this.pageNo = pageNo;
+        this.totalCount = totalCount;
+    }
 }

--- a/src/main/java/com/bubble/bubbleforprofessor/university/dto/response/UniversityApiResponse.java
+++ b/src/main/java/com/bubble/bubbleforprofessor/university/dto/response/UniversityApiResponse.java
@@ -12,9 +12,7 @@ import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @XmlRootElement(name = "response")
 @Getter
@@ -25,10 +23,16 @@ import lombok.Setter;
 XmlAccessType.FIELD: 모든 필드(심지어 private도 포함)를 직접 접근해서 데이터를 넣어줘, getter/setter가 없어도 필드 자체를 사용할 수 있게 해줌
 * */
 @NoArgsConstructor
+@Builder
 public class UniversityApiResponse {
     @XmlElement(name = "header")
     private Header header;
 
     @XmlElement(name = "body")
     private Body body;
+
+    public UniversityApiResponse(Header header, Body body) {
+        this.header = header;
+        this.body = body;
+    }
 }

--- a/src/main/java/com/bubble/bubbleforprofessor/university/dto/response/UniversityList.java
+++ b/src/main/java/com/bubble/bubbleforprofessor/university/dto/response/UniversityList.java
@@ -3,17 +3,21 @@ package com.bubble.bubbleforprofessor.university.dto.response;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Getter
 @XmlAccessorType(XmlAccessType.FIELD)
 @NoArgsConstructor
+@Builder
 public class UniversityList {
     @XmlElement(name = "OBJT_ID")
     private Long objectId;
 
     @XmlElement(name = "FCLTY_NM")
     private String universityName;
+
+    public UniversityList(Long objectId, String universityName) {
+        this.objectId = objectId;
+        this.universityName = universityName;
+    }
 }

--- a/src/main/java/com/bubble/bubbleforprofessor/university/entity/University.java
+++ b/src/main/java/com/bubble/bubbleforprofessor/university/entity/University.java
@@ -7,11 +7,10 @@ import org.springframework.data.annotation.Id;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 @Getter
+@Builder
 @Document(indexName = "universities") //indexName에 대문자 들어가면안됨, Elasticsearch는 HTTP 기반 API를 사용하는데, URL 경로에서 대소문자 문제를 방지하려고 소문자만 허용
 @Table(name="University")
-@Builder
 public class University {
 
     @Id
@@ -24,6 +23,13 @@ public class University {
 
     @Column(name="is_deleted", nullable = false)
     private boolean isDeleted;
+
+
+    public University(Long universityId, String universityName, boolean isDeleted) {
+        this.universityId = universityId;
+        this.universityName = universityName;
+        this.isDeleted = isDeleted;
+    }
 
     public void updateNameIfChanged(String newName) {
         if (!this.universityName.equals(newName)) {
@@ -40,4 +46,5 @@ public class University {
     public void markAsDeleted() {
         this.isDeleted = true;
     }
+
 }

--- a/src/test/java/com/bubble/bubbleforprofessor/chatroom/service/impl/ChatroomUserServiceImplTest.java
+++ b/src/test/java/com/bubble/bubbleforprofessor/chatroom/service/impl/ChatroomUserServiceImplTest.java
@@ -19,6 +19,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
@@ -55,7 +56,10 @@ class ChatroomUserServiceImplTest {
     @Test
     void testCreateChatroomUser()
     {
-        University university = new University("example university");
+        University university = University.builder()
+                .universityName("조선대학교")
+                .build();
+
         Role professorRole = new Role("PROFESSOR");
         Role userRole = new Role("USER");
         //교수

--- a/src/test/java/com/bubble/bubbleforprofessor/skin/service/impl/SkinServiceImplTest.java
+++ b/src/test/java/com/bubble/bubbleforprofessor/skin/service/impl/SkinServiceImplTest.java
@@ -47,7 +47,10 @@ class SkinServiceImplTest {
     private SkinImage skinImage2;
     private User user;
     private Role role = new Role("ROLE_USER");
-    private University university = new University("조선대학교");
+    private University university = University.builder()
+            .universityName("조선대학교")
+            .build();
+
     private Category category = new Category("글꼴");
     private UUID userId;
     private UserSkin userSkin;// UserSkin mock object

--- a/src/test/java/com/bubble/bubbleforprofessor/university/service/UniversityServiceImplTest.java
+++ b/src/test/java/com/bubble/bubbleforprofessor/university/service/UniversityServiceImplTest.java
@@ -6,6 +6,7 @@ import com.bubble.bubbleforprofessor.university.dto.response.Body;
 import com.bubble.bubbleforprofessor.university.dto.response.UniversityApiResponse;
 import com.bubble.bubbleforprofessor.university.dto.response.UniversityList;
 import com.bubble.bubbleforprofessor.university.entity.University;
+import com.bubble.bubbleforprofessor.university.repository.es.UniversityElasticSearchRepository;
 import com.bubble.bubbleforprofessor.university.repository.jpa.UniversityRepository;
 
 import com.bubble.bubbleforprofessor.university.service.UniversityServiceImpl;
@@ -25,6 +26,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.when;
@@ -38,8 +40,8 @@ class UniversityServiceImplTest {
     UniversityRepository universityRepository;
 
     /*Mock :  가짜로 만든 객체
-    * InjectMoks : 테스트 대상에 Mock 주입
-    * Mockito는 when 설정을 테스트가 시작되기 전에 모두 메모리에 저장*/
+     * InjectMoks : 테스트 대상에 Mock 주입
+     * Mockito는 when 설정을 테스트가 시작되기 전에 모두 메모리에 저장*/
 
     @Mock
     private WebClient webClient;
@@ -53,6 +55,9 @@ class UniversityServiceImplTest {
 
     @Mock
     private WebClient.RequestHeadersUriSpec requestHeadersUriSpec;
+
+    @Mock
+    private UniversityElasticSearchRepository esSearchRepository;
 
     @Mock
     private WebClient.RequestHeadersSpec requestHeadersSpec;
@@ -72,22 +77,25 @@ class UniversityServiceImplTest {
     private UniversityServiceImpl universityServiceImplTest;
 
 
-
     @Test
     void onelist() {
         //give
-        UniversityApiRequest request = new UniversityApiRequest();
-        request.setServiceKey("test");
-        request.setPageNo(1);
-        request.setNumOfRows(10);
-        request.setDataType("xml");
-        request.setFcltyCd("50112");
+        UniversityApiRequest request = UniversityApiRequest.builder()
+                .serviceKey("test")
+                .pageNo(1)
+                .numOfRows(666)
+                .dataType("xml")
+                .fcltyCd("50112")
+                .build();
 
-        //가짜 응답 준비
-        UniversityApiResponse response = new UniversityApiResponse();
-        Body body = new Body();
-        body.setTotalCount(666);
-        response.setBody(body);
+        // given: 응답 DTO (Body + UniversityApiResponse) 도 Builder로 생성
+        Body body = Body.builder()
+                .totalCount(666)
+                .build();
+
+        UniversityApiResponse response = UniversityApiResponse.builder()
+                .body(body)
+                .build();
         when(responseSpec.bodyToMono(UniversityApiResponse.class)).thenReturn(Mono.just(response));
 
         //when (실행)
@@ -99,113 +107,68 @@ class UniversityServiceImplTest {
                 .verifyComplete(); //Mono가 끝났는지 확인
     }
 
-    /*
-    @Test
-    void saveAllUniversities() {
-        //give
-        //1. totalcount 값 얻어오기
-        UniversityApiRequest getTotalCount = new UniversityApiRequest();
-        getTotalCount.setServiceKey("test");
-        getTotalCount.setPageNo(1);
-        getTotalCount.setDataType("xml");
-        getTotalCount.setFcltyCd("50112");
-
-        //2. 가짜 TotalCount 준비
-        UniversityApiResponse initResponse = new UniversityApiResponse();
-        Body initBody = new Body();
-        initBody.setTotalCount(666);
-        initResponse.setBody(initBody);
-
-        //todo 가짜 데이터를 왜 아래 when을 사용할까?
-        //      그 데이터를 saveAllUniversities매서드에 전달할려면 webClient가 데이터를 넣어주도록 설정위해 필요 (비동기 처리위함)
-        //      responseSpec : 응답을 처리하는 객체, WebClient를 통해 HTTP 요청을 보내고, 그에 대한 HTTP 응답을 받을 때 사용
-        //      bodyToMono() :  HTTP 응답 본문을 특정 Java 객체로 변환하는 메소드
-        when(responseSpec.bodyToMono(UniversityApiResponse.class)).thenReturn(Mono.just(initResponse));
-
-        doNothing().when(universityRepository).deleteAll();
-
-        //3. 전체 대학교 데이터 요청준비
-        UniversityApiRequest allUniRequest = new UniversityApiRequest();
-        allUniRequest.setServiceKey("test");
-        allUniRequest.setPageNo(1);
-        allUniRequest.setDataType("xml");
-        allUniRequest.setNumOfRows(initBody.getTotalCount());
-        allUniRequest.setFcltyCd("50112");
-
-
-        //4. 전체 데이터 응답
-        UniversityApiResponse fullResponse = new UniversityApiResponse();
-        Body fullBody = new Body();
-        UniversityList items = new UniversityList();
-        items.setUniversityName("한국대학교");
-        fullBody.setItems(List.of(items));
-        fullResponse.setBody(fullBody);
-
-        when(responseSpec.bodyToMono(UniversityApiResponse.class)).thenReturn(Mono.just(fullResponse));
-        when(universityRepository.saveAll(anyList())).thenReturn(Collections.emptyList());
-
-        // When
-        Mono<Void> result = universityServiceImplTest.saveAllUniversities(allUniRequest);
-
-        // Then
-        StepVerifier.create(result)
-                .verifyComplete();
-        verify(universityRepository, times(1)).deleteAll(); // deleteAll 호출 확인
-        verify(universityRepository, times(1)).saveAll(anyList()); // saveAll 호출 확인
-    }
-*/
 
     @Test
     void saveAllUniversities() {
-        // 1. Total count 설정
-        UniversityApiResponse initResponse = new UniversityApiResponse();
-        Body initBody = new Body();
-        initBody.setTotalCount(666);
-        initResponse.setBody(initBody);
+        // given
+        // 1. totalCount 응답
+        Body initBody = Body.builder()
+                .totalCount(666)
+                .build();
+        UniversityApiResponse initResponse = UniversityApiResponse.builder()
+                .body(initBody)
+                .build();
         when(responseSpec.bodyToMono(UniversityApiResponse.class)).thenReturn(Mono.just(initResponse));
 
-        doNothing().when(universityRepository).deleteAll();
+        // 2. 기존 저장된 대학 목록 (1건 있음)
+        University existingUniversity = University.builder()
+                .universityId(1L)
+                .universityName("이전대학교")
+                .isDeleted(false)
+                .build();
+        when(universityRepository.findAll()).thenReturn(List.of(existingUniversity));
 
-        // 2. 전체 데이터 설정
-        UniversityApiResponse fullResponse = new UniversityApiResponse();
-        Body fullBody = new Body();
-        UniversityList items = new UniversityList();
-        items.setUniversityName("한국대학교");
-        items.setObjectId(1L);
-        fullBody.setItems(List.of(items));
-        fullResponse.setBody(fullBody);
+        // 3. 새로 받아올 데이터 (기존과 다른 이름으로 덮어쓰기 유도)
+        UniversityList newItem = UniversityList.builder()
+                .objectId(1L)
+                .universityName("한국대학교") // 이름 변경됨
+                .build();
+        Body fullBody = Body.builder()
+                .items(List.of(newItem))
+                .build();
+        UniversityApiResponse fullResponse = UniversityApiResponse.builder()
+                .body(fullBody)
+                .build();
         when(responseSpec.bodyToMono(UniversityApiResponse.class)).thenReturn(Mono.just(fullResponse));
-        when(universityRepository.findAll()).thenReturn(Collections.emptyList());
         when(universityRepository.saveAll(anyList())).thenReturn(Collections.emptyList());
 
-        UniversityApiRequest allUniRequest = new UniversityApiRequest();
-        allUniRequest.setServiceKey("test");
-        allUniRequest.setPageNo(1);
-        allUniRequest.setDataType("xml");
-        allUniRequest.setNumOfRows(666);
-        allUniRequest.setFcltyCd("50112");
+        UniversityApiRequest request = UniversityApiRequest.builder()
+                .serviceKey("test")
+                .pageNo(1)
+                .numOfRows(666)
+                .dataType("xml")
+                .fcltyCd("50112")
+                .build();
 
-        // When
-        Mono<Void> result = universityServiceImplTest.saveAllUniversities(allUniRequest);
+        // when
+        Mono<Void> result = universityServiceImplTest.saveAllUniversities(request);
 
-        // Then
+        // then
         StepVerifier.create(result).verifyComplete();
-        verify(universityRepository, times(1)).deleteAll();
-        verify(universityRepository, times(1)).saveAll(anyList());
 
+        verify(universityRepository, times(1)).findAll();
+        verify(universityRepository, times(1)).saveAll(anyList());
 
         ArgumentCaptor<List<University>> captor = ArgumentCaptor.forClass(List.class);
         verify(universityRepository).saveAll(captor.capture());
 
         List<University> savedUniversities = captor.getValue();
-        assertEquals(1, savedUniversities.size());
+        assertThat(savedUniversities).hasSize(1);
 
         University saved = savedUniversities.get(0);
-        assertEquals("한국대학교", saved.getUniversityName());
-        assertEquals(1L, saved.getUniversityId());
-        assertFalse(saved.isDeleted());
+        assertThat(saved.getUniversityId()).isEqualTo(1L);
+        assertThat(saved.getUniversityName()).isEqualTo("한국대학교");
     }
-
 
 
 }

--- a/src/test/java/com/bubble/bubbleforprofessor/user/service/impl/ProfessorServiceImplTest.java
+++ b/src/test/java/com/bubble/bubbleforprofessor/user/service/impl/ProfessorServiceImplTest.java
@@ -63,7 +63,9 @@ class ProfessorServiceImplTest {
     @BeforeEach
     void setUp() {
         userId = UUID.randomUUID();
-        University university = new University("Test University");
+        University university = University.builder()
+                .universityName("조선대학교")
+                .build();
 
         user = User.builder()
                 .id(userId)
@@ -132,7 +134,7 @@ class ProfessorServiceImplTest {
         // then
         assertEquals(1, result.getTotalElements());
         ApprovalRequestDto dto = result.getContent().get(0);
-        assertEquals("Test University", dto.getUniversityName());
+        assertEquals("조선대학교", dto.getUniversityName());
         assertEquals("Computer Science", dto.getDepartment());
         assertEquals(12345, dto.getProfessorNum());
         assertEquals("John Doe", dto.getProfessorName());


### PR DESCRIPTION
## Feature
- 서버 실행시 외부API 사용하여 대학교리스트 DB에 저장
- 1년에 한번 11월 22일 대학교 (추후 상수화 리팩터링 예정)
- 대학교 삭제시 soft_delete 적용 추후 -> 재 개교시 True(폐교상태) -> False(개교상태) 변경 적용
- 대학교DB 업데이트 -> 학교이름 변경시 기존 사용자가 저장된 대학교이름도 자동 변환 로직 적용

---

## 🧪 Test
### 1. `onelist()`
- 목적: 초기 요청(`numOfRows = 1`)에 대한 응답에서 `totalCount` 값을 제대로 받아오는지 검증
- 방식:
  - `UniversityApiRequest`를 이용해 WebClient 요청
  - `UniversityApiResponse`의 `body.totalCount` 값을 `Mono<Integer>`로 반환
- 검증: `StepVerifier`를 사용해 `expectNext(666)`으로 `totalCount` 정확히 반환 확인

---

### 2. `saveAllUniversities()`
- 목적: 외부 API로부터 전체 대학 목록을 받아와 DB에 저장하는 전체 흐름 테스트
- 시나리오:
  1. 초기 요청으로 `totalCount` 값 확인
  2. `totalCount`만큼 데이터 요청 후 새로운 대학 리스트 응답 받음
  3. 기존 DB에 있는 대학과 비교해 이름이 다르면 업데이트
  4. 변경된 데이터만 `saveAll`로 저장
- 검증:
  - `findAll()`과 `saveAll()`이 정확히 1번씩 호출되는지 확인
  - 저장된 객체가 실제로 수정된 이름("한국대학교")인지 `ArgumentCaptor`로 검증