### PR TITLE
Refator: University enity - elasticSearch 문서 분리 및 JPA 이중 호출 문제 해결

### DIFF
--- a/src/main/java/com/bubble/bubbleforprofessor/BubbleforprofessorApplication.java
+++ b/src/main/java/com/bubble/bubbleforprofessor/BubbleforprofessorApplication.java
@@ -1,22 +1,10 @@
 package com.bubble.bubbleforprofessor;
 
-import com.bubble.bubbleforprofessor.university.repository.es.UniversityElasticSearchRepository;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
-import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
 
 @SpringBootApplication
-@EnableJpaRepositories(
-		basePackages = "com.bubble.bubbleforprofessor",
-		excludeFilters = @ComponentScan.Filter(
-				type = FilterType.ASSIGNABLE_TYPE,
-				classes = UniversityElasticSearchRepository.class
-		)
-)
-@EnableElasticsearchRepositories(basePackages = "com.bubble.bubbleforprofessor.university.repository.es")
 public class BubbleforprofessorApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/bubble/bubbleforprofessor/university/controller/UniversityController.java
+++ b/src/main/java/com/bubble/bubbleforprofessor/university/controller/UniversityController.java
@@ -1,5 +1,6 @@
 package com.bubble.bubbleforprofessor.university.controller;
 
+import com.bubble.bubbleforprofessor.university.document.UniversityDocument;
 import com.bubble.bubbleforprofessor.university.dto.request.UniversityApiRequest;
 import com.bubble.bubbleforprofessor.university.entity.University;
 import com.bubble.bubbleforprofessor.university.service.UniversityService;
@@ -45,7 +46,7 @@ public class UniversityController {
     @GetMapping("/search")
     public ResponseEntity<Map<String, Object>> universitySearch(@RequestParam String uniname) {
         try {
-            List<University> universities = universityService.searchUniversity(uniname);
+            List<UniversityDocument> universities = universityService.searchUniversity(uniname);
             Map<String, Object> response = new HashMap<>();
             response.put("status", 200);
             response.put("message", "대학교 조회 성공");

--- a/src/main/java/com/bubble/bubbleforprofessor/university/document/UniversityDocument.java
+++ b/src/main/java/com/bubble/bubbleforprofessor/university/document/UniversityDocument.java
@@ -1,0 +1,38 @@
+package com.bubble.bubbleforprofessor.university.document;
+
+import com.bubble.bubbleforprofessor.university.entity.University;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Document(indexName = "universities") //indexName에 대문자 들어가면안됨, Elasticsearch는 HTTP 기반 API를 사용하는데, URL 경로에서 대소문자 문제를 방지하려고 소문자만 허용
+public class UniversityDocument {
+
+    @Id
+    private Long universityId;
+
+    private String universityName;
+
+    private boolean isDeleted;
+
+
+    @Builder
+    private UniversityDocument(Long universityId, String universityName, boolean isDeleted) {
+        this.universityId = universityId;
+        this.universityName = universityName;
+        this.isDeleted = isDeleted;
+    }
+
+    public static UniversityDocument fromEntity(University university) {
+        return UniversityDocument.builder()
+                .universityId(university.getUniversityId())
+                .universityName(university.getUniversityName())
+                .isDeleted(university.isDeleted())
+                .build();
+    }
+}

--- a/src/main/java/com/bubble/bubbleforprofessor/university/entity/University.java
+++ b/src/main/java/com/bubble/bubbleforprofessor/university/entity/University.java
@@ -9,7 +9,6 @@ import org.springframework.data.annotation.Id;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Builder
-@Document(indexName = "universities") //indexName에 대문자 들어가면안됨, Elasticsearch는 HTTP 기반 API를 사용하는데, URL 경로에서 대소문자 문제를 방지하려고 소문자만 허용
 @Table(name="University")
 public class University {
 

--- a/src/main/java/com/bubble/bubbleforprofessor/university/repository/es/UniversityElasticSearchRepository.java
+++ b/src/main/java/com/bubble/bubbleforprofessor/university/repository/es/UniversityElasticSearchRepository.java
@@ -1,13 +1,14 @@
 package com.bubble.bubbleforprofessor.university.repository.es;
 
+import com.bubble.bubbleforprofessor.university.document.UniversityDocument;
 import com.bubble.bubbleforprofessor.university.entity.University;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 @Repository("ElasticSearchRepository")
-public interface UniversityElasticSearchRepository extends ElasticsearchRepository<University, Long> {
-    List<University> findByUniversityNameContaining(String name);
+public interface UniversityElasticSearchRepository extends ElasticsearchRepository<UniversityDocument, Long> {
+    List<UniversityDocument> findByUniversityNameContaining(String name);
 
 
     // 부분 일치 검색으로 변경

--- a/src/main/java/com/bubble/bubbleforprofessor/university/service/UniversityService.java
+++ b/src/main/java/com/bubble/bubbleforprofessor/university/service/UniversityService.java
@@ -1,5 +1,6 @@
 package com.bubble.bubbleforprofessor.university.service;
 
+import com.bubble.bubbleforprofessor.university.document.UniversityDocument;
 import com.bubble.bubbleforprofessor.university.dto.request.UniversityApiRequest;
 import com.bubble.bubbleforprofessor.university.entity.University;
 import reactor.core.publisher.Mono;
@@ -10,5 +11,5 @@ public interface UniversityService {
     Mono<Void> saveAllUniversities(UniversityApiRequest uniRequest);
     Mono<Integer> onelist(UniversityApiRequest request);
 
-    List<University> searchUniversity(String uniname);
+    List<UniversityDocument> searchUniversity(String uniname);
 }

--- a/src/main/java/com/bubble/bubbleforprofessor/university/service/UniversityServiceImpl.java
+++ b/src/main/java/com/bubble/bubbleforprofessor/university/service/UniversityServiceImpl.java
@@ -1,5 +1,6 @@
 package com.bubble.bubbleforprofessor.university.service;
 
+import com.bubble.bubbleforprofessor.university.document.UniversityDocument;
 import com.bubble.bubbleforprofessor.university.dto.request.UniversityApiRequest;
 import com.bubble.bubbleforprofessor.university.dto.response.UniversityApiResponse;
 import com.bubble.bubbleforprofessor.university.entity.University;
@@ -205,17 +206,21 @@ public class UniversityServiceImpl implements UniversityService {
 
     //대학교list DB -> Elasticsearch에 저장
     private void indexUniversityies(List<University> universities){
-        esSearchRepository.saveAll(universities);
+        List<UniversityDocument> documents = universities.stream()
+                .map(UniversityDocument::fromEntity)   // University → UniversityDocument 변환
+                .collect(Collectors.toList());
+
+        esSearchRepository.saveAll(documents);
         log.info("색인된 대학교 갯수 : {} ", universities.size());
     }
 
 
     //검색 메서드
-    public List<University> searchUniversity(String uniname){
+    public List<UniversityDocument> searchUniversity(String uniname){
         if (uniname == null || uniname.trim().isEmpty()) { //null 확인 및  앞뒤 공백을 제거한 후 빈 문자열인지 확인
             throw new CustomException(ErrorCode.UNIVERSITYNAME_INVALID_REQUEST);
         }
-        List<University> universities = esSearchRepository.findByUniversityNameContaining(uniname);
+        List<UniversityDocument> universities = esSearchRepository.findByUniversityNameContaining(uniname);
         if (universities.isEmpty()) {
             throw new CustomException(ErrorCode.UNIVERSITY_NOT_FOUND);
         }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,7 +44,7 @@ logging:
       glassfish:
         jaxb: debug
     root: INFO
-    com.bubble.buubleforprofessor: DEBUG
+    com.bubble.bubbleforprofessor: DEBUG
 
 
 jwt:

--- a/src/test/java/com/bubble/bubbleforprofessor/university/service/UniversityServiceImplTest.java
+++ b/src/test/java/com/bubble/bubbleforprofessor/university/service/UniversityServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.bubble.bubbleforprofessor.university.service;
 
+import com.bubble.bubbleforprofessor.university.document.UniversityDocument;
 import com.bubble.bubbleforprofessor.university.dto.request.UniversityApiRequest;
 
 import com.bubble.bubbleforprofessor.university.dto.response.Body;
@@ -123,7 +124,7 @@ class UniversityServiceImplTest {
         // 2. 기존 저장된 대학 목록 (1건 있음)
         University existingUniversity = University.builder()
                 .universityId(1L)
-                .universityName("이전대학교")
+                .universityName("한국대학교")
                 .isDeleted(false)
                 .build();
         when(universityRepository.findAll()).thenReturn(List.of(existingUniversity));
@@ -131,7 +132,7 @@ class UniversityServiceImplTest {
         // 3. 새로 받아올 데이터 (기존과 다른 이름으로 덮어쓰기 유도)
         UniversityList newItem = UniversityList.builder()
                 .objectId(1L)
-                .universityName("한국대학교") // 이름 변경됨
+                .universityName("조선대학교") // 이름 변경됨
                 .build();
         Body fullBody = Body.builder()
                 .items(List.of(newItem))
@@ -156,19 +157,20 @@ class UniversityServiceImplTest {
         // then
         StepVerifier.create(result).verifyComplete();
 
-        verify(universityRepository, times(1)).findAll();
-        verify(universityRepository, times(1)).saveAll(anyList());
-
-        ArgumentCaptor<List<University>> captor = ArgumentCaptor.forClass(List.class);
-        verify(universityRepository).saveAll(captor.capture());
-
-        List<University> savedUniversities = captor.getValue();
+        // DB 저장 검증
+        ArgumentCaptor<List<University>> universityCaptor = ArgumentCaptor.forClass(List.class);
+        verify(universityRepository, times(1)).saveAll(universityCaptor.capture());
+        List<University> savedUniversities = universityCaptor.getValue();
         assertThat(savedUniversities).hasSize(1);
+        assertThat(savedUniversities.get(0).getUniversityName()).isEqualTo("조선대학교");
 
-        University saved = savedUniversities.get(0);
-        assertThat(saved.getUniversityId()).isEqualTo(1L);
-        assertThat(saved.getUniversityName()).isEqualTo("한국대학교");
+        // Elasticsearch 색인 검증
+        ArgumentCaptor<List<UniversityDocument>> esCaptor = ArgumentCaptor.forClass(List.class);
+        verify(esSearchRepository, times(1)).saveAll(esCaptor.capture());
+        List<UniversityDocument> indexedDocuments = esCaptor.getValue();
+        assertThat(indexedDocuments).hasSize(1);
+        assertThat(indexedDocuments.get(0).getUniversityName()).isEqualTo("조선대학교");
+    }
     }
 
 
-}


### PR DESCRIPTION
## 📌 Summary
- 기존 University 엔티티로 JPA + Elasticsearch를 동시에 사용하던 문제를  application.yml 경로지정을 리팩터링
- UniversityDocument를 별도 생성하여, 엔티티-문서 구조를 분리
- 이에 따라 application.yml 및 Application 설정을 단순화

✅ Features
- UniversityDocument 추가
- UniversityElasticSearchRepository 수정
- UniversityServiceImpl 저장/색인 분리